### PR TITLE
[Feature] Show upstream DNS in query log

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,2 @@
-- Improved deployment: 12Mb Docker image, 1-line install script, and publish to crates.io
-- Adds documentation
-- Faster start-up time
+Adds new coloumn to query log, showing the upstream DNS server used for the query (#2)
+Also updates the query log table to be responsive, so on smaller screens the upstream DNS and client IP won't be visible.

--- a/.github/README.md
+++ b/.github/README.md
@@ -23,6 +23,9 @@ Features:
 - **Easy and Lightweight**: _AdGuardian can be run either with a super tiny Docker image, or directly with the zero-dependency executable_
 - **Good and Safe**: _Written in Rust and unit tested, the app runs locally with no external requests, and (of course) it's fully open source_
 
+About AdGuard:
+
+[AdGuard Home](https://github.com/AdguardTeam/AdGuardHome) is a free and open source self-hosted (or managed) network-wide ad + tracker blocker. It operates as a DNS server that re-routes tracking domains to a "black hole", thus preventing your devices from connecting to those servers. It makes your internet, faster, safer and gives you a bunch of useful features, like encrypted DNS (DoH, DoT, DNSCrypt), parental controls, blocking of malware / phishing, per-device configs, custom DNS rules, etc.
 
 <details>
 <summary><b>Contents</b></summary>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "adguardian"
-version = "0.9.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adguardian"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = ["Alicia Sykes"]
 description = "Terminal-based, real-time traffic monitoring and statistics for your AdGuard Home instance "

--- a/src/fetch/fetch_query_log.rs
+++ b/src/fetch/fetch_query_log.rs
@@ -12,6 +12,7 @@ pub struct QueryResponse {
 pub struct Query {
     pub cached: bool,
     pub client: String,
+    pub upstream: String,
     #[serde(rename = "elapsedMs")]
     pub elapsed_ms: String,
     pub question: Question,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -64,7 +64,7 @@ pub async fn draw_ui(
 
             // Make the charts
             let gauge = make_gauge(&stats);
-            let table = make_query_table(&data);
+            let table = make_query_table(&data, size.width);
             let graph = make_history_chart(&stats);
             let paragraph = render_status_paragraph(&status, &stats);
             let filters = make_filters_list(filters.filters.as_slice(), size.width);

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -14,7 +14,7 @@ pub fn make_query_table(data: &[Query]) -> Table<'_> {
       let time = Cell::from(
           time_ago(query.time.as_str()).unwrap_or("unknown".to_string())
       ).style(Style::default().fg(Color::Gray));
-
+      
       let question = Cell::from(make_request_cell(&query.question).unwrap())
           .style(Style::default().add_modifier(Modifier::BOLD));
 
@@ -27,8 +27,10 @@ pub fn make_query_table(data: &[Query]) -> Table<'_> {
       let (status_txt, status_color) = block_status_text(&query.reason, query.cached);
       let status = Cell::from(status_txt).style(Style::default().fg(status_color));
 
+      let upstream = Cell::from(query.upstream.as_str()).style(Style::default().fg(Color::Blue));
+
       let color = make_row_color(&query.reason);
-      Row::new(vec![time, question, status, client, elapsed_ms])
+      Row::new(vec![time, question, status, client, upstream, elapsed_ms])
           .style(Style::default().fg(color))
   }).collect::<Vec<Row>>(); // Clone the data here
 
@@ -38,6 +40,7 @@ pub fn make_query_table(data: &[Query]) -> Table<'_> {
         Cell::from(Span::raw("Request")),
         Cell::from(Span::raw("Status")),
         Cell::from(Span::raw("Client")),
+        Cell::from(Span::raw("Upstream DNS")),
         Cell::from(Span::raw("Time Taken")),
       ]))
       .block(
@@ -50,9 +53,10 @@ pub fn make_query_table(data: &[Query]) -> Table<'_> {
       .widths(&[
         Constraint::Percentage(15),
         Constraint::Percentage(35),
+        Constraint::Percentage(10),
         Constraint::Percentage(15),
-        Constraint::Percentage(20),
         Constraint::Percentage(15),
+        Constraint::Percentage(10),
       ]);
 
   table


### PR DESCRIPTION
**Description**
This PR introduces a new coloumn to the query log table, which shows the upstream DNS server used to resolve a given query.

**Note:**
The table got quite cramped on smaller screens, so this colom will be hidden if your terminal width is below 120 chars. Blocked requests do not have an upstream DNS provider, and so will be blank. If you've only got one DNS server configured, the value will be the same for each request.


**Ticket**: #2

**Screenshot**: 

![image](https://github.com/Lissy93/AdGuardian-Term/assets/1862727/2abfe825-7561-4f2c-a793-7717abd63395)
