### PR TITLE
[Feature] Support for HTTPS / User-defined protocol

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,2 +1,1 @@
-Catch error caused by unknown AdGuard field, last_updated (#5)
-Add support for ARMv7 and ARM_64 binaries (#4)
+Enables support for HTTPS, via optional user-defined protocol (#7)

--- a/.github/README.md
+++ b/.github/README.md
@@ -136,6 +136,11 @@ The following params are accepted:
 - `ADGUARD_USERNAME` / `--adguard-username` - An AdGuard Home username
 - `ADGUARD_PASSWORD` / `--adguard-password` - An AdGuard Home password
 
+There's also some additional optional environment variables that you may set:
+
+- `ADGUARD_PROTOCOL` - The protocol to use when connecting to AdGuard (defaults to `http`)
+- `ADGUARD_UPDATE_INTERVAL` - The rate at which to refresh the UI in seconds (defaults to `2`)
+
 <details>
 <summary>Examples</summary>
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "adguardian"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adguardian"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 authors = ["Alicia Sykes"]
 description = "Terminal-based, real-time traffic monitoring and statistics for your AdGuard Home instance "

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,9 +24,11 @@ async fn run() -> anyhow::Result<()> {
     // AdGuard instance details, from env vars (verified in welcome.rs)
     let ip = env::var("ADGUARD_IP")?;
     let port = env::var("ADGUARD_PORT")?;
-    let hostname = format!("http://{}:{}", ip, port);
+    let protocol = env::var("ADGUARD_PROTOCOL").unwrap_or("http".to_string());
+    let hostname = format!("{}://{}:{}", protocol, ip, port);
     let username = env::var("ADGUARD_USERNAME")?;
     let password = env::var("ADGUARD_PASSWORD")?;
+    
 
     // Fetch data that doesn't require updates
     let filters = fetch_adguard_filter_list(&client, &hostname, &username, &password).await?;

--- a/src/welcome.rs
+++ b/src/welcome.rs
@@ -62,6 +62,7 @@ async fn verify_connection(
     client: &Client,
     ip: String,
     port: String,
+    protocol: String,
     username: String,
     password: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -72,7 +73,7 @@ async fn verify_connection(
     let mut headers = reqwest::header::HeaderMap::new();
     headers.insert("Authorization", auth_header_value.parse()?);
 
-    let url = format!("http://{}:{}/control/status", ip, port);
+    let url = format!("{}://{}:{}/control/status", protocol, ip, port);
 
     match client
         .get(&url)
@@ -105,6 +106,9 @@ pub async fn welcome() -> Result<(), Box<dyn std::error::Error>> {
         ("--adguard-password", "ADGUARD_PASSWORD"),
     ];
 
+    let protocol: String = env::var("ADGUARD_PROTOCOL").unwrap_or_else(|_| "http".into()).parse()?;
+    env::set_var("ADGUARD_PROTOCOL", protocol);
+
     // Parse command line arguments
     let mut args = std::env::args().peekable();
     while let Some(arg) = args.next() {
@@ -136,8 +140,9 @@ pub async fn welcome() -> Result<(), Box<dyn std::error::Error>> {
 
     let ip = get_env("ADGUARD_IP")?;
     let port = get_env("ADGUARD_PORT")?;
+    let protocol = get_env("ADGUARD_PROTOCOL")?;
     let username = get_env("ADGUARD_USERNAME")?;
     let password = get_env("ADGUARD_PASSWORD")?;
-
-    verify_connection(&client, ip, port, username, password).await
+    
+    verify_connection(&client, ip, port, protocol, username, password).await
 }


### PR DESCRIPTION
**Description:** Enables user to set the protocol used, in order to access AdGuard dashboards served over anything other than http (aka https).

**Ticket:** #7 

**Note:** The protocol used will default to `http` if not defined / so is backwards compatible. You can set `ADGUARD_PROTOCOL="https"` to use HTTPS. I've tested with a self-signed cert, and seems to work okay
(Oh, and if you're using a custom domain, then set that to `ADGUARD_IP`, and set `ADGUARD_PORT` to `80` or wherever it's running at).