### PR TITLE
[Fix] Processing Time Incorrect

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,2 +1,1 @@
-Adds a check to ensure that the users version of AdGuard Home is recent enough to support the required API calls (#5)
-Allows for graceful exit, instead of panicking
+Fixes the units in Average Processing Time (seconds were incorrectly displayed as milliseconds) (#11)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "adguardian"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adguardian"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 authors = ["Alicia Sykes"]
 description = "Terminal-based, real-time traffic monitoring and statistics for your AdGuard Home instance "

--- a/src/widgets/status.rs
+++ b/src/widgets/status.rs
@@ -51,7 +51,7 @@ pub fn render_status_paragraph<'a>(status: &'a StatusResponse, stats: &'a StatsR
     ]),
     Spans::from(vec![
       Span::styled("Avg Processing Time: ", Style::default()),
-      Span::styled(format!("{}ms", stats.avg_processing_time), value_style),
+      Span::styled(format!("{}ms", (stats.avg_processing_time * 1000.0) as i16), value_style),
     ]),
     Spans::from(vec![
       Span::styled("Version: ", Style::default()),


### PR DESCRIPTION
**Overview**: The processing time displayed was incorrect. AdGuard's API was returning the value in seconds, while AdGuardian was displaying it as milliseconds. This has been fixed by dividing by 1000 and converting to a 16-bit integer.


**Ticket**: #11

**Screenshot**:

<img src="https://github.com/Lissy93/AdGuardian-Term/assets/1862727/99b1a79d-df21-4e85-b7e3-f36b263fb827" width="400" />
