### PR TITLE
Ttyd-Dockerfile 

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -200,6 +200,9 @@ The terminal dashboard can also be viewed via a browser, thanks to [ttyd](https:
 AdGuardian is fully compatible with ttyd, so once you've [installed](https://github.com/tsl0922/ttyd#installation) it, you can just precede your run command with ttyd.
 E.g. `ttyd docker run -it lissy93/adguardian` or `ttyd adguardian`
 
+You can also just use the ttyd-Dockerfile, this will build the latest AdGuardian-Term from github and the latest ttyd and compiles both together into a single dockerfile.
+So you don't have to install ttyd on the host, due to security reasons.
+
 This might be useful for embedding into another app or dashboard (like Dashy 😉 - although Dashy already has an [AdGuard widget](https://github.com/Lissy93/dashy/blob/master/docs/widgets.md#adguard-home-block-stats)!) 
 
 <p align="center">

--- a/ttyd-Dockerfile
+++ b/ttyd-Dockerfile
@@ -1,0 +1,38 @@
+# Use Debian as base image
+FROM debian:latest
+
+# Install necessary build tools
+RUN apt-get update && \
+    apt-get install -y sudo build-essential cmake git libjson-c-dev libwebsockets-dev zlib1g-dev curl
+
+# Install Rust and Cargo
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
+    export PATH="$HOME/.cargo/bin:$PATH" && \
+    rustup default stable
+
+
+# Clone and build ttyd
+RUN git clone https://github.com/tsl0922/ttyd.git && \
+    cd ttyd && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make && \
+    make install
+
+# Clone AdGuardian-Term and build
+RUN git clone https://github.com/Lissy93/AdGuardian-Term.git && \
+    cd AdGuardian-Term && \
+    $HOME/.cargo/bin/cargo build --release && \
+    mv ./target/release/adguardian /usr/local/bin/adguardian
+
+# Expose port 7681
+EXPOSE 7681
+
+ENV ADGUARD_IP={define your adguard ip here}
+ENV ADGUARD_PORT={define the adguard port here, most likely 80}
+ENV ADGUARD_USERNAME={add you username of adguard here}
+ENV ADGUARD_PASSWORD={add your adguard password here}
+
+# Set the start command
+CMD ["ttyd", "-W","-c", "${ADGUARD_USERNAME}:${ADGUARD_PASSWORD}", "/usr/local/bin/adguardian"]


### PR DESCRIPTION
Add a dockerfile that automatically builds the latest ttyd and adguardian-term inside a docker container, so I do not have to run ttyd on my host system, which seems a bit more secure than running it on the host.

If you want to change anything, or add it to your workflow of GH Actions, feel free to.

Altough a bit sad, that I couldn't use it yet, as the adguardian seems broken.