### PR TITLE
[Feature] Show client names, DNS rewrites

### DIFF
--- a/src/fetch/fetch_query_log.rs
+++ b/src/fetch/fetch_query_log.rs
@@ -16,6 +16,8 @@ pub struct Query {
     #[serde(rename = "elapsedMs")]
     pub elapsed_ms: String,
     pub question: Question,
+    #[serde(default)]
+    pub client_info: Option<ClientInfo>,
     pub reason: String,
     pub time: String,
 }
@@ -26,6 +28,11 @@ pub struct Question {
     pub name: String,
     #[serde(rename = "type")]
     pub question_type: String,
+}
+
+#[derive(Deserialize)]
+pub struct ClientInfo {
+    pub name: Option<String>,
 }
 
 pub async fn fetch_adguard_query_log(

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,14 @@ async fn run() -> anyhow::Result<()> {
                     return Err(anyhow::anyhow!("Failed to send query data"));
                 }
                 
-                let stats = fetch_adguard_stats(&client, &hostname, &username, &password).await?;
+                let (mut stats, client_map) = fetch_adguard_stats(&client, &hostname, &username, &password).await?;
+                
+                for domain in &mut stats.top_clients {
+                    if let Some(client_name) = client_map.get(&domain.name) {
+                        domain.name = client_name.clone();
+                    }
+                }
+                
                 if stats_tx.send(stats).await.is_err() {
                     return Err(anyhow::anyhow!("Failed to send stats data"));
                 }

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -17,7 +17,13 @@ pub fn make_query_table(data: &[Query], width: u16) -> Table<'_> {
       let question = Cell::from(make_request_cell(&query.question).unwrap())
           .style(Style::default().add_modifier(Modifier::BOLD));
 
-      let client = Cell::from(query.client.as_str())
+      let client_names = query.client_info
+          .as_ref()
+          .and_then(|info| info.name.as_deref())
+          .filter(|name| !name.is_empty())
+          .map_or_else(|| query.client.as_str(), |name| name);
+      
+      let client = Cell::from(client_names)
           .style(Style::default().fg(Color::Blue));
 
       let (time_taken, elapsed_color) = make_time_taken_and_color(&query.elapsed_ms).unwrap();
@@ -125,6 +131,8 @@ fn make_row_color(reason: &str) -> Color {
       Color::Green
   } else if reason == "FilteredBlackList" {
       Color::Red
+  } else if reason == "Rewrite" {
+      Color::LightGreen
   } else {
       Color::Yellow
   }
@@ -137,6 +145,8 @@ fn block_status_text(reason: &str, cached: bool) -> (String, Color) {
       ("Blacklisted".to_string(), Color::Red)
   } else if cached {
       ("Cached".to_string(), Color::Cyan)
+  } else if reason == "Rewrite" {
+      ("Rewrite".to_string(), Color::LightGreen)
   } else if reason == "NotFilteredNotFound" {
       ("Allowed".to_string(), Color::Green)
   } else {


### PR DESCRIPTION
Using:

```
$ rustc --version
rustc 1.69.0
```

I made two minor changes that I needed; you're welcome to take/tweak.

---

**Changes made:**

 - Added *#33* to hide IP addresses (AdGuard Home | Settings > Client Settings > [Add Client] > Identifier = Client's IP address). This change helps those who either don't want to expose their local IPs to people in the room, or don't want to remember which IP goes to what.
 - Added *Rewrite* option because my local domains (most trusted) were showing up as "Other Block" (Yellow) instead of "Rewrite" (LightGreen).

---

Thank you for creating this project!