### PR TITLE
Add Reference to Third-Party Docker Image for Web Mode

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -202,6 +202,9 @@ The terminal dashboard can also be viewed via a browser, thanks to [ttyd](https:
 The easiest way to run AdGuardian in web mode is using a pre-built Docker image:
 
 > **Note**: This is a third-party Docker image (`sdjnmxd/adguardian-web`) and is not officially maintained by the AdGuardian-Term project. Use at your own discretion.
+> 
+> **🐳 Docker Hub**: [sdjnmxd/adguardian-web](https://hub.docker.com/r/sdjnmxd/adguardian-web)  
+> **📚 Source Code**: [GitHub Repository](https://github.com/sdjnmxd/adguardian-web)
 
 ```bash
 docker run -d \


### PR DESCRIPTION
Hey! I've been using AdGuardian-Term for a while and really love it. I noticed that setting up the web mode can be a bit tricky for some users, so I created a pre-built Docker image to make it easier.

### What I Added
Just a simple reference in the Web Mode section pointing to `sdjnmxd/adguardian-web` on Docker Hub. Users can now run:

```bash
docker run -d \
  -p 7681:7681 \
  -e ADGUARD_IP=your.adguard.ip \
  -e ADGUARD_PORT=80 \
  -e ADGUARD_USERNAME=admin \
  -e ADGUARD_PASSWORD=your_password \
  sdjnmxd/adguardian-web
```

### Why I Made a Separate Repo
I thought about contributing directly here, but decided to keep it separate because:
- The web version has some specific Docker optimizations that might clutter the main repo
- Easier to maintain and update independently
- Users get a choice between terminal and web versions

### The Image Features
- Uses Ubuntu 22.04 with ttyd pre-installed
- Downloads the latest AdGuardian binary
- Runs as non-root user
- Includes helpful error messages if env vars are missing
- Has health checks built-in

### Disclaimer
I made sure to add a clear note that this is a third-party image, so users know it's not officially maintained by this project.

Let me know if you'd prefer a different approach or if there's anything I should change!