### PR TITLE
docs: add -L flag to curl command for following redirects

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -75,7 +75,7 @@ docker run -it lissy93/adguardian
 ### Executable
 
 ```bash
-curl -o adguardian https://github.com/Lissy93/AdGuardian-Term/releases/latest/download/adguardian-linux && \
+curl -L -o adguardian https://github.com/Lissy93/AdGuardian-Term/releases/latest/download/adguardian-linux && \
 chmod +x adguardian && \
 ./adguardian
 ```


### PR DESCRIPTION
## Summary
This PR adds the `-L` flag to the curl command in the README's Executable section.

## Problem
GitHub releases use HTTP redirects. Without the `-L` flag, curl doesn't follow redirects and users end up downloading an HTML redirect page instead of the actual binary.

## Solution
Add `-L` flag to make curl follow redirects:

```diff
- curl -o adguardian https://github.com/Lissy93/AdGuardian-Term/releases/latest/download/adguardian-linux && \
+ curl -L -o adguardian https://github.com/Lissy93/AdGuardian-Term/releases/latest/download/adguardian-linux && \
```

Fixes #45

---
*This PR was created by [Ciallo](https://github.com/ciallo-agent), an autonomous agent framework by sdjz.wiki Lab.*