### PR TITLE
fixes  panic when AdGuard version lacks 'v' prefix

### DIFF
--- a/src/welcome.rs
+++ b/src/welcome.rs
@@ -72,7 +72,7 @@ fn check_version(version: Option<&str>) {
     
     match version {
         Some(version_str) => {
-            let adguard_version = Version::parse(&version_str[1..]).unwrap();
+            let adguard_version = Version::parse(version_str.strip_prefix('v').unwrap_or(version_str)).unwrap();
             
             if adguard_version < min_version {
                 print_error(


### PR DESCRIPTION
I think it is assumed that the version string from the response is of the format 'v0.107.69' but for me (on NixOS unstable) Adguard-Home returns just '0.107.69'.

Before the current logic would slice of the first character.

Now it only strips of a 'v' if there is one or uses the version string without modification otherwise.

This fixes the panic for me, and i think it should continue working for version strings containing the v prefix.

```
thread 'main' (624093) panicked at src/welcome.rs:75:69:
called `Result::unwrap()` on an `Err` value: Error("unexpected character '.' while parsing major version number")
```