### PR TITLE
Fix typo in README for AdGuardian Terminal Edition

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -8,7 +8,7 @@
 
 ## About
 
-AdGuardian Terminal Eddition - Keep an eye on your traffic, with this (unofficial) buddy for your AdGuard Home instance
+AdGuardian Terminal Edition - Keep an eye on your traffic, with this (unofficial) buddy for your AdGuard Home instance
 
 <p align="center">
 <img width="600" src="https://i.ibb.co/Nrtd01d/adguardian-demo.gif?" >


### PR DESCRIPTION
I found one typo in the README, happy to help