### PR TITLE
Even faster docker builds, no QEMU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
+      rust: ${{ steps.filter.outputs.rust }}
       docker: ${{ steps.filter.outputs.docker }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+      deps: ${{ steps.filter.outputs.deps }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -35,14 +38,28 @@ jobs:
         uses: dorny/paths-filter@v4
         with:
           filters: |
+            rust:
+              - 'src/**'
+              - 'build.rs'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
             docker:
               - 'Dockerfile*'
+              - 'src/**'
+              - 'build.rs'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+            workflows:
+              - '.github/workflows/**'
+            deps:
               - 'Cargo.toml'
               - 'Cargo.lock'
 
   # Run format check, to ensure code nice and pretty
   fmt:
     name: 🎨 Format
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -62,6 +79,8 @@ jobs:
   # Run clippy, to ensure no rust warnings
   clippy:
     name: 📎 Clippy
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -84,6 +103,8 @@ jobs:
   # Execute the tests
   test:
     name: 🧪 Test
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -104,6 +125,8 @@ jobs:
   # Do build check, ensure everything builds
   build:
     name: 🔨 Build
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -124,6 +147,8 @@ jobs:
   # Check the docs build with no warnings or broken intra-doc links
   docs:
     name: 📚 Docs
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -178,20 +203,32 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Build image (no push)
+      - name: Build image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64
-          push: false
-          load: false
+          load: true
+          tags: adguardian:ci
           cache-from: type=gha,scope=ci-docker
           cache-to: type=gha,mode=max,scope=ci-docker
+
+      - name: Smoke test (image starts)
+        env:
+          IMAGE: adguardian:ci
+        run: |
+          set -euo pipefail
+          output=$(timeout 30 docker run --rm "$IMAGE" </dev/null 2>&1 || true)
+          echo "$output"
+          echo "$output" | grep -q "AdGuardian Terminal Edition" \
+            || { echo "::error::Image built but did not start as expected"; exit 1; }
 
   # Review the workflow files are valid and free of security issues
   workflow-lint:
     name: ⚙️ Workflow lint
+    needs: changes
+    if: needs.changes.outputs.workflows == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -234,7 +271,8 @@ jobs:
   # Dependency changes have no known vulnerabilities
   dependency-review:
     name: ⛓️‍💥 Dependency review
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.deps == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,11 @@
 # Triggered by git tag creation, which publishes to the same docker tag.
 # Each platform is built on its own runner in parallel and pushed by digest;
 # a final merge job stitches the digests into one manifest list per registry,
-# then attaches provenance + SBOM attestations. arm64 builds natively on an
-# arm runner; the 32-bit glibc variants (arm/v7, 386) are emulated via QEMU.
+# then attaches provenance + SBOM attestations.
+#
+# Platforms: amd64 (native), arm64 (native arm runner), and arm/v7, 386,
+# ppc64le, s390x (glibc, cross-compiled on amd64). No emulation is used, so
+# QEMU is not needed.
 
 name: 🐳 Docker
 
@@ -97,24 +100,26 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # 64-bit: ultra-light scratch/musl image (Dockerfile)
+          # 64-bit: ultra-light scratch/musl image (Dockerfile), built natively
           - platform: linux/amd64
             runner: ubuntu-latest
             dockerfile: ./Dockerfile
-            qemu: false
           - platform: linux/arm64
-            runner: ubuntu-24.04-arm   # native arm64 — no emulation
+            runner: ubuntu-24.04-arm
             dockerfile: ./Dockerfile
-            qemu: false
-          # 32-bit: glibc/Debian image (Dockerfile.full); emulated, but parallel
+          # glibc/Debian image (Dockerfile.full), cross-compiled on amd64
           - platform: linux/arm/v7
             runner: ubuntu-latest
             dockerfile: ./Dockerfile.full
-            qemu: true
           - platform: linux/386
             runner: ubuntu-latest
             dockerfile: ./Dockerfile.full
-            qemu: true
+          - platform: linux/ppc64le
+            runner: ubuntu-latest
+            dockerfile: ./Dockerfile.full
+          - platform: linux/s390x
+            runner: ubuntu-latest
+            dockerfile: ./Dockerfile.full
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v6
@@ -125,10 +130,6 @@ jobs:
         env:
           PLATFORM: ${{ matrix.platform }}
         run: echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> "$GITHUB_ENV"
-
-      - name: 🧰 Set up QEMU
-        if: matrix.qemu
-        uses: docker/setup-qemu-action@v4
 
       - name: 🧱 Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -1,28 +1,61 @@
 # syntax=docker/dockerfile:1
 
-# glibc (Debial) based Docker image for AdGuardian-Term
-# Because the ultra-lightweight scratch version doesn't work on 32-bit arch
+# glibc (Debian) based image for AdGuardian-Term
+# used for the targets where the scratch/musl build doesn't work:
+# the 32-bit arches, plus the big-iron 64-bit ppc64le / s390x
+#
+# The binary needs to be CROSS-compiled on the native build platform and then
+# packaged into a target-arch runtime image
 
-# Build: compile the binary for the TARGET arch
-FROM rust:1.90-slim-bookworm AS builder
+# Build: cross-compile for the requested target
+FROM --platform=$BUILDPLATFORM rust:1.90-slim-bookworm AS builder
+ARG TARGETPLATFORM
+
+# Base build tooling
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential cmake clang perl \
+    && apt-get install -y --no-install-recommends \
+       build-essential cmake clang perl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
+
+# Install the cross C toolchain + matching Rust target for the target platform
+RUN set -eux; \
+    case "$TARGETPLATFORM" in \
+      "linux/arm/v7")  rust_target=armv7-unknown-linux-gnueabihf; gnu=arm-linux-gnueabihf ;; \
+      "linux/386")     rust_target=i686-unknown-linux-gnu;        gnu=i686-linux-gnu ;; \
+      "linux/ppc64le") rust_target=powerpc64le-unknown-linux-gnu; gnu=powerpc64le-linux-gnu ;; \
+      "linux/s390x")   rust_target=s390x-unknown-linux-gnu;       gnu=s390x-linux-gnu ;; \
+      *) echo "Unsupported TARGETPLATFORM: $TARGETPLATFORM" >&2; exit 1 ;; \
+    esac; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends "gcc-${gnu}" "g++-${gnu}"; \
+    rm -rf /var/lib/apt/lists/*; \
+    rustup target add "$rust_target"; \
+    triple_upper=$(echo "$rust_target" | tr 'a-z-' 'A-Z_'); \
+    triple_under=$(echo "$rust_target" | tr '-' '_'); \
+    { \
+      echo "export RUST_TARGET=${rust_target}"; \
+      echo "export CARGO_TARGET_${triple_upper}_LINKER=${gnu}-gcc"; \
+      echo "export CC_${triple_under}=${gnu}-gcc"; \
+      echo "export CXX_${triple_under}=${gnu}-g++"; \
+      echo "export AR_${triple_under}=${gnu}-ar"; \
+    } > /cross-env.sh
+
 WORKDIR /app
 COPY . .
-ARG TARGETPLATFORM
 RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-reg-full-${TARGETPLATFORM} \
-    cargo build --release && cp target/release/adguardian /adguardian
+    . /cross-env.sh \
+    && cargo build --release --target "$RUST_TARGET" \
+    && cp "target/${RUST_TARGET}/release/adguardian" /adguardian
 
-# Runtime: minimal glibc base with CA certs, run as non-root
+# Runtime: minimal glibc base, CA certs copied from builder, run as non-root.
+# No RUN here, so this stage needs no emulation despite being target-arch
 FROM debian:bookworm-slim
 LABEL org.opencontainers.image.title="AdGuardian-Term" \
       org.opencontainers.image.description="Real-time traffic monitoring for AdGuard Home, in your terminal" \
       org.opencontainers.image.source="https://github.com/Lissy93/AdGuardian-Term" \
       org.opencontainers.image.licenses="MIT"
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /adguardian /usr/local/bin/adguardian
 USER 65534:65534
 ENTRYPOINT ["/usr/local/bin/adguardian"]


### PR DESCRIPTION
Should solve the 25 min ARM/v7 compilation issue on GitHub Actions, by using native runner instead
also makes ci a bit faster, by only running the checks needed based on what code changed, and now the docker smoke test actually smokes too